### PR TITLE
pinned jupyter_server version and downgraded @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maap-jupyter-server-extension",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A JupyterLab extension.",
   "keywords": [
     "jupyter",
@@ -54,7 +54,7 @@
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@jupyterlab/builder": "^3.1.0",
-    "@types/node": "^16.14.2",
+    "@types/node": "^14.18.32",
     "mkdirp": "^1.0.3",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
     install_requires=[
-        "jupyter_server>=2,<3"
+        "jupyter_server==2.12.5"
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
- pinned jupyter_server to 2.12.5 because v2.13.0 was causing a bug in the ADE for workspaces to not launch
- downgraded @types/node because changing the version of typescript/ removing typescript wasn’t working trying to get the README commands working, so I kept the version the same and the only error I was getting was `node_modules/@types/node/ts4.8/events.d.ts(72,43): error TS2370: A rest parameter must be of an array type.` so I went through the GitHub for @types/node and tried to find a version where that line was done differently
- upgraded jupyter server extension to 1.2.3 and published on pip 

Note that:
I kept getting this error trying to install maap_jupyter_server_extension from test pypi,
```
ERROR: Could not find a version that satisfies the requirement jupyter-server==2.12.5 (from maap-jupyter-server-extension) (from versions: 0.0.1a0, 1.5.2, 1.5.3, 1.5.5, 1.7.0a0, 100.5.1, 100.100.1)
```
And it was because those are the only versions of jupyter_server in test pypi: https://test.pypi.org/project/jupyter-server/#history
