### PR TITLE
Feature/add dependency reqs

### DIFF
--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -17,6 +17,7 @@ import yaml
 import time
 
 logging.basicConfig(format='%(asctime)s %(message)s')
+print("graceal1 in handlers.py")
 
 @functools.lru_cache(maxsize=128)
 def get_maap_config(host):
@@ -366,6 +367,9 @@ class GetQueryHandler(IPythonHandler):
 
 class IFrameHandler(IPythonHandler):
     def initialize(self, welcome=None, sites=None):
+        print("graceal1 in initialize with")
+        print(welcome)
+        print(sites)
         self.sites = sites
         self.welcome = welcome
 

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -17,7 +17,6 @@ import yaml
 import time
 
 logging.basicConfig(format='%(asctime)s %(message)s')
-print("graceal1 in handlers.py")
 
 @functools.lru_cache(maxsize=128)
 def get_maap_config(host):
@@ -367,9 +366,6 @@ class GetQueryHandler(IPythonHandler):
 
 class IFrameHandler(IPythonHandler):
     def initialize(self, welcome=None, sites=None):
-        print("graceal1 in initialize with")
-        print(welcome)
-        print(sites)
         self.sites = sites
         self.welcome = welcome
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,15 @@ classifiers = [
 ]
 dependencies = [
     "jupyter_server>=2.0.1,<2.13.0",
-    "xmltodict~=0.13.0"
+    "xmltodict~=0.13.0",
+    "nbformat~=5.10.3",
+    "notebook~=6.4.12",
+    "pytest~=8.1.1",
+    "PyYAML~=6.0.1",
+    "Requests~=2.31.0",
+    "setuptools~=69.0",
+    "tornado~=6.4",
+    "maap-py@git+https://github.com/MAAP-Project/maap-py.git@v4.0.0#egg=maapPy"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
@@ -32,6 +40,9 @@ source = "nodejs"
 
 [tool.hatch.metadata.hooks.nodejs]
 fields = ["description", "authors", "urls"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.sdist]
 artifacts = ["maap_jupyter_server_extension/labextension"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "Requests~=2.31.0",
     "setuptools~=69.0",
     "tornado~=6.4",
+    "jupyter-nbextensions-configurator~=0.6.4",
     "maap-py@git+https://github.com/MAAP-Project/maap-py.git@v4.0.0#egg=maapPy"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]


### PR DESCRIPTION
Updated pyproject.toml to reflect packages required before: https://github.com/MAAP-Project/jupyter-server-extension/issues/4

I downgraded to notebook v6.4.12 and removed jupyter_packaging because I believe that was only used for our old way of deploying packages. I also had to upgrade setuptools to fix dependency conflicts and chose to upgrade maap-py to v4.0.0

I tested this by running through all the development install commands successfully

I had to add 
```
[tool.hatch.metadata]
allow-direct-references = true
``` 
to be able to install maap-py from git, but we can remove that line when maap-py is available from PyPi