### PR TITLE
Removed install of maap-py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,7 @@ dependencies = [
     "Requests~=2.31.0",
     "setuptools~=69.0",
     "tornado~=6.4",
-    "jupyter-nbextensions-configurator~=0.6.4",
-    "maap-py@git+https://github.com/MAAP-Project/maap-py.git@v4.0.0#egg=maapPy"
+    "jupyter-nbextensions-configurator~=0.6.4"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
@@ -41,9 +40,6 @@ source = "nodejs"
 
 [tool.hatch.metadata.hooks.nodejs]
 fields = ["description", "authors", "urls"]
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.hatch.build.targets.sdist]
 artifacts = ["maap_jupyter_server_extension/labextension"]


### PR DESCRIPTION
If you have `"maap-py@git+https://github.com/MAAP-Project/maap-py.git@v4.0.0#egg=maapPy"` in the dependency installs, when you try to upload to PyPi you will get an error message like 
```
Can't have direct dependency: maap-py@ git+https://github.com/MAAP-Project/maap-py.git@feature/maappy-gets-username#egg=maapPy.
```
Just keeping this PR as a draft as a heads up about this, once we deploy maap-py as a pip package this shouldn't be a problem, but if we cannot do that by the next release we will have to temporarily remove maap-py as a dependency of jupyter server extension so that we can successfully publish this extension