### PR TITLE
Feature/remove api maap py instantiation

### DIFF
--- a/maap_jupyter_server_extension/constants.py
+++ b/maap_jupyter_server_extension/constants.py
@@ -1,0 +1,2 @@
+API_OPTIONS = ["api.dit.maap-project.org", "api.uat.maap-project.org", "api.maap-project.org"]
+ADE_OPTIONS = ["ade.dit.maap-project.org", "ade.uat.maap-project.org", "ade.maap-project.org"]

--- a/maap_jupyter_server_extension/constants.py
+++ b/maap_jupyter_server_extension/constants.py
@@ -1,2 +1,4 @@
 API_OPTIONS = ["api.dit.maap-project.org", "api.uat.maap-project.org", "api.maap-project.org"]
+DEFAULT_API = "api.dit.maap-project.org"
 ADE_OPTIONS = ["ade.dit.maap-project.org", "ade.uat.maap-project.org", "ade.maap-project.org"]
+DEFAULT_ADE = "ade.maap-project.org"

--- a/maap_jupyter_server_extension/constants.py
+++ b/maap_jupyter_server_extension/constants.py
@@ -1,4 +1,3 @@
-API_OPTIONS = ["api.dit.maap-project.org", "api.uat.maap-project.org", "api.maap-project.org"]
-DEFAULT_API = "api.dit.maap-project.org"
 ADE_OPTIONS = ["ade.dit.maap-project.org", "ade.uat.maap-project.org", "ade.maap-project.org"]
 DEFAULT_ADE = "ade.maap-project.org"
+DEFAULT_API = "api.maap-project.org"

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -18,38 +18,14 @@ import time
 import urllib.parse
 
 logging.basicConfig(format='%(asctime)s %(message)s')
-print("graceal1 in handlers of jupyter server extension")
 
 @functools.lru_cache(maxsize=128)
 def get_maap_config(host):
-    print("graceal1 in get_maap_config with host")
-    print(host)
-    # NOTE need to extract the path from the API 
-    # What about a weird case where API host is sent or vice versa and not the other? 
-    # Need to add error checking
     api_host = os.getenv("MAAP_API_HOST", "api.maap-project.org")
     maap_api_config_endpoint = os.getenv("MAAP_API_CONFIG_ENDPOINT", "api/environment/config")
     ade_host = host if host in ["ade.dit.maap-project.org", "ade.uat.maap-project.org", "ade.maap-project.org"] else os.getenv("MAAP_ADE_HOST", "ade.maap-project.org")
     environments_endpoint = "https://" + api_host + "/" + maap_api_config_endpoint + "/"+urllib.parse.quote(urllib.parse.quote("https://", safe=""))+ade_host
-    print("graceal1 attempting to fetch")
-    print(environments_endpoint)
-    # need to properly get this request 
-    maap_config = requests.get(environments_endpoint)
-    print(maap_config)
-    maap_config = maap_config.json()
-    print(maap_config)
-
-    # path_to_json = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', os.environ['ENVIRONMENTS_FILE_PATH'])
-    
-    # with open(path_to_json) as f:
-    #     data = json.load(f)
-
-    # match = next((x for x in data if host in x['ade_server']), None)
-    # maap_config = next((x for x in data if x['default_host'] == True), None) if match is None else match
-    print("graceal1 Printing from maap config")
-    print(maap_config)
-    return maap_config
-
+    return requests.get(environments_endpoint).json()
 
 def maap_api(host):
     return get_maap_config(host)['api_server']

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -167,7 +167,6 @@ class GetCMRCollectionsHandler(IPythonHandler):
 
 class ListUserJobsHandler(IPythonHandler):
     def get(self):
-        print("graceal1 in ListUserJobsHandler")
         #maap = MAAP(not_self_signed=False)
         maap = MAAP()
 

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -28,7 +28,7 @@ def get_maap_config(host):
     # NOTE need to extract the path from the API 
     # What about a weird case where API host is sent or vice versa and not the other? 
     api_host = os.environ.get("MAAP_API_HOST") or "api.maap-project.org"
-    ade_host = os.environ.get("MAAP_ADE_HOST") or "ade.maap-project.org"
+    ade_host = host or "ade.maap-project.org"
     environments_endpoint = "https://" + api_host + "/api/environment/config/"+urllib.parse.quote(urllib.parse.quote("https://", safe=""))+ade_host
     print("graceal1 attempting to fetch")
     print(environments_endpoint)

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -24,14 +24,16 @@ print("graceal1 in handlers of jupyter server extension")
 def get_maap_config(host):
     print("graceal1 in get_maap_config with host")
     print(host)
-    print(os.environ)
     # NOTE need to extract the path from the API 
     # What about a weird case where API host is sent or vice versa and not the other? 
-    api_host = os.environ.get("MAAP_API_HOST") or "api.maap-project.org"
-    ade_host = host or "ade.maap-project.org"
-    environments_endpoint = "https://" + api_host + "/api/environment/config/"+urllib.parse.quote(urllib.parse.quote("https://", safe=""))+ade_host
+    # Need to add error checking
+    api_host = os.getenv("MAAP_API_HOST", "api.maap-project.org")
+    maap_api_config_endpoint = os.getenv("MAAP_API_CONFIG_ENDPOINT", "api/environment/config")
+    ade_host = host if host in ["ade.dit.maap-project.org", "ade.uat.maap-project.org", "ade.maap-project.org"] else os.getenv("MAAP_ADE_HOST", "api.maap-project.org")
+    environments_endpoint = "https://" + api_host + "/" + maap_api_config_endpoint + "/"+urllib.parse.quote(urllib.parse.quote("https://", safe=""))+ade_host
     print("graceal1 attempting to fetch")
     print(environments_endpoint)
+    # need to properly get this request 
     maap_config = requests.get(environments_endpoint)
     print(maap_config)
     maap_config = maap_config.json()

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -17,10 +17,25 @@ import yaml
 import time
 
 logging.basicConfig(format='%(asctime)s %(message)s')
+print("graceal1 in handlers of jupyter server extension")
 
 @functools.lru_cache(maxsize=128)
 def get_maap_config(host):
+    print("graceal1 in get_maap_config with host")
+    print(host)
     print(os.environ)
+    # NOTE need to extract the path from the API 
+    # What about a weird case where API host is sent or vice versa and not the other? 
+    # api_host = os.environ.get("MAAP_API_HOST") or "api.maap-project.org"
+    # ade_host = os.environ.get("MAAP_ADE_HOST") or "ade.maap-project.org"
+    # environments_endpoint = "https://" + api_host + "/api/environment/config/"+urllib.parse.quote(urllib.parse.quote("https://", safe=""))+ade_host
+    # print("graceal1 attempting to fetch")
+    # print(environments_endpoint)
+    # r = requests.get(environments_endpoint)
+    # print(r)
+    # r = r.json()
+    # print(r)
+
     path_to_json = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', os.environ['ENVIRONMENTS_FILE_PATH'])
     
     with open(path_to_json) as f:
@@ -28,7 +43,7 @@ def get_maap_config(host):
 
     match = next((x for x in data if host in x['ade_server']), None)
     maap_config = next((x for x in data if x['default_host'] == True), None) if match is None else match
-    print("Printing from maap config")
+    print("graceal1 Printing from maap config")
     print(maap_config)
     return maap_config
 

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -76,18 +76,6 @@ class MAAPConfigEnvironmentHandler(APIHandler):
         env = get_maap_config(self.request.host)
         self.finish(env)
 
-
-class KibanaConfigHandler(APIHandler):
-    # The following decorator should be present on all verb methods (head, get, post,
-    # patch, put, delete, options) to ensure only authorized user can request the
-    # Jupyter server
-    @tornado.web.authenticated
-    def get(self):
-        url = get_kibana_url(maap_api(self.request.host))
-        print(url)
-        self.finish({"KIBANA_URL": url})
-
-
 class WorkspaceContainerHandler(APIHandler):
     # The following decorator should be present on all verb methods (head, get, post,
     # patch, put, delete, options) to ensure only authorized user can request the
@@ -124,8 +112,7 @@ class ListAlgorithmsHandler(IPythonHandler):
         print("In python list algos handler")
 
         #maap = MAAP(not_self_signed=False)
-        maap = MAAP(maap_host=maap_api(self.request.host))
-        print(maap_api(self.request.host))
+        maap = MAAP()
 
         try:
             print("Making query from backend.")
@@ -139,7 +126,7 @@ class ListAlgorithmsHandler(IPythonHandler):
 class DescribeAlgorithmsHandler(IPythonHandler):
     def get(self):
         #maap = MAAP(not_self_signed=False)
-        maap = MAAP(maap_host=maap_api(self.request.host))
+        maap = MAAP()
 
         try:
             r = maap.describeAlgorithm(self.get_argument("algo_id"))
@@ -153,7 +140,7 @@ class DescribeAlgorithmsHandler(IPythonHandler):
 class GetQueuesHandler(IPythonHandler):
     def get(self):
         #maap = MAAP(not_self_signed=False)
-        maap = MAAP(maap_host=maap_api(self.request.host))
+        maap = MAAP()
         try:
             r = maap.getQueues()
             resp = json.loads(r.text)
@@ -167,7 +154,7 @@ class GetQueuesHandler(IPythonHandler):
 class GetCMRCollectionsHandler(IPythonHandler):
     def get(self):
         #maap = MAAP(not_self_signed=False)
-        maap = MAAP(maap_host=maap_api(self.request.host))
+        maap = MAAP()
 
         try:
             r = maap.searchCollection()
@@ -181,7 +168,7 @@ class GetCMRCollectionsHandler(IPythonHandler):
 class ListUserJobsHandler(IPythonHandler):
     def get(self):
         #maap = MAAP(not_self_signed=False)
-        maap = MAAP(maap_host=maap_api(self.request.host))
+        maap = MAAP()
 
         try:
             r = maap.listJobs(self.get_argument("username"))
@@ -204,7 +191,7 @@ class SubmitJobHandler(IPythonHandler):
 
         kwargs = self.args_to_dict()
         #maap = MAAP(not_self_signed=False)
-        maap = MAAP(maap_host=maap_api(self.request.host))
+        maap = MAAP()
         resp = maap.submitJob(**kwargs)
         #logger.debug(resp)
         
@@ -223,7 +210,7 @@ class SubmitJobHandler(IPythonHandler):
 
 class CancelJobHandler(IPythonHandler):
     def get(self):
-        maap = MAAP(maap_host=maap_api(self.request.host))
+        maap = MAAP()
         response = ""
         exception_code = ""
 
@@ -255,7 +242,7 @@ class CancelJobHandler(IPythonHandler):
 class GetJobStatusHandler(IPythonHandler):
     def get(self):
         #maap = MAAP(not_self_signed=False)
-        maap = MAAP(maap_host=maap_api(self.request.host))
+        maap = MAAP()
 
         try:
             r = maap.getJobStatus(self.get_argument("job_id"))
@@ -271,7 +258,7 @@ class GetJobStatusHandler(IPythonHandler):
 class GetJobResultHandler(IPythonHandler):
     def get(self):
         #maap = MAAP(not_self_signed=False)
-        maap = MAAP(maap_host=maap_api(self.request.host))
+        maap = MAAP()
 
         try:
             r = maap.getJobResult(self.get_argument("job_id"))
@@ -287,7 +274,7 @@ class GetJobResultHandler(IPythonHandler):
 class RegisterWithFileHandler(IPythonHandler):
     def get(self):
         #maap = MAAP(not_self_signed=False)
-        maap = MAAP(maap_host=maap_api(self.request.host))
+        maap = MAAP()
 
         try:
             config_file = self.get_argument("file")
@@ -305,7 +292,7 @@ class RegisterWithFileHandler(IPythonHandler):
 class GetJobMetricsHandler(IPythonHandler):
     def get(self):
         #maap = MAAP(not_self_signed=False)
-        maap = MAAP(maap_host=maap_api(self.request.host))
+        maap = MAAP()
 
         try:
             r = maap.getJobMetrics(self.get_argument("job_id"))
@@ -336,7 +323,7 @@ class GetGranulesHandler(IPythonHandler):
         return url_list
 
     def get(self):
-        maap = MAAP(maap_api(self.request.host))
+        maap = MAAP()
         cmr_query = self.get_argument('cmr_query', '')
         limit = str(self.get_argument('limit', ''))
         print("cmr_query", cmr_query)
@@ -353,7 +340,7 @@ class GetGranulesHandler(IPythonHandler):
 
 class GetQueryHandler(IPythonHandler):
     def get(self):
-        maap = MAAP(maap_api(self.request.host))
+        maap = MAAP()
         cmr_query = self.get_argument('cmr_query', '')
         limit = str(self.get_argument('limit', ''))
         query_type = self.get_argument('query_type', 'granule')

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -15,6 +15,7 @@ import logging
 import requests
 import yaml
 import time
+import urllib.parse
 
 logging.basicConfig(format='%(asctime)s %(message)s')
 print("graceal1 in handlers of jupyter server extension")
@@ -26,23 +27,23 @@ def get_maap_config(host):
     print(os.environ)
     # NOTE need to extract the path from the API 
     # What about a weird case where API host is sent or vice versa and not the other? 
-    # api_host = os.environ.get("MAAP_API_HOST") or "api.maap-project.org"
-    # ade_host = os.environ.get("MAAP_ADE_HOST") or "ade.maap-project.org"
-    # environments_endpoint = "https://" + api_host + "/api/environment/config/"+urllib.parse.quote(urllib.parse.quote("https://", safe=""))+ade_host
-    # print("graceal1 attempting to fetch")
-    # print(environments_endpoint)
-    # r = requests.get(environments_endpoint)
-    # print(r)
-    # r = r.json()
-    # print(r)
+    api_host = os.environ.get("MAAP_API_HOST") or "api.maap-project.org"
+    ade_host = os.environ.get("MAAP_ADE_HOST") or "ade.maap-project.org"
+    environments_endpoint = "https://" + api_host + "/api/environment/config/"+urllib.parse.quote(urllib.parse.quote("https://", safe=""))+ade_host
+    print("graceal1 attempting to fetch")
+    print(environments_endpoint)
+    maap_config = requests.get(environments_endpoint)
+    print(maap_config)
+    maap_config = maap_config.json()
+    print(maap_config)
 
-    path_to_json = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', os.environ['ENVIRONMENTS_FILE_PATH'])
+    # path_to_json = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', os.environ['ENVIRONMENTS_FILE_PATH'])
     
-    with open(path_to_json) as f:
-        data = json.load(f)
+    # with open(path_to_json) as f:
+    #     data = json.load(f)
 
-    match = next((x for x in data if host in x['ade_server']), None)
-    maap_config = next((x for x in data if x['default_host'] == True), None) if match is None else match
+    # match = next((x for x in data if host in x['ade_server']), None)
+    # maap_config = next((x for x in data if x['default_host'] == True), None) if match is None else match
     print("graceal1 Printing from maap config")
     print(maap_config)
     return maap_config

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -16,18 +16,15 @@ import requests
 import yaml
 import time
 import urllib.parse
-import constants
+import maap_jupyter_server_extension.constants as constants
 
 logging.basicConfig(format='%(asctime)s %(message)s')
 
 @functools.lru_cache(maxsize=128)
 def get_maap_config(host):
-    print("graceal1 in get_maap_config and constants are")
-    print(constants.ADE_OPTIONS)
-    print(constants.API_OPTIONS)
-    api_host = os.getenv("MAAP_API_HOST", "api.maap-project.org")
+    api_host = os.getenv("MAAP_API_HOST", constants.DEFAULT_API)
     maap_api_config_endpoint = os.getenv("MAAP_API_CONFIG_ENDPOINT", "api/environment/config")
-    ade_host = host if host in ["ade.dit.maap-project.org", "ade.uat.maap-project.org", "ade.maap-project.org"] else os.getenv("MAAP_ADE_HOST", "ade.maap-project.org")
+    ade_host = host if host in constants.ADE_OPTIONS else os.getenv("MAAP_ADE_HOST", constants.DEFAULT_ADE)
     environments_endpoint = "https://" + api_host + "/" + maap_api_config_endpoint + "/"+urllib.parse.quote(urllib.parse.quote("https://", safe=""))+ade_host
     return requests.get(environments_endpoint).json()
 

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -29,7 +29,7 @@ def get_maap_config(host):
     # Need to add error checking
     api_host = os.getenv("MAAP_API_HOST", "api.maap-project.org")
     maap_api_config_endpoint = os.getenv("MAAP_API_CONFIG_ENDPOINT", "api/environment/config")
-    ade_host = host if host in ["ade.dit.maap-project.org", "ade.uat.maap-project.org", "ade.maap-project.org"] else os.getenv("MAAP_ADE_HOST", "api.maap-project.org")
+    ade_host = host if host in ["ade.dit.maap-project.org", "ade.uat.maap-project.org", "ade.maap-project.org"] else os.getenv("MAAP_ADE_HOST", "ade.maap-project.org")
     environments_endpoint = "https://" + api_host + "/" + maap_api_config_endpoint + "/"+urllib.parse.quote(urllib.parse.quote("https://", safe=""))+ade_host
     print("graceal1 attempting to fetch")
     print(environments_endpoint)

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -167,11 +167,12 @@ class GetCMRCollectionsHandler(IPythonHandler):
 
 class ListUserJobsHandler(IPythonHandler):
     def get(self):
+        print("graceal1 in ListUserJobsHandler")
         #maap = MAAP(not_self_signed=False)
         maap = MAAP()
 
         try:
-            r = maap.listJobs(self.get_argument("username"))
+            r = maap.listJobs()
             self.finish({"status_code": r.status_code, "response": r.json()})
         except:
             print("Failed list jobs query.")

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -17,7 +17,6 @@ import yaml
 import time
 
 logging.basicConfig(format='%(asctime)s %(message)s')
-print("graceal1 in handlers.py")
 
 @functools.lru_cache(maxsize=128)
 def get_maap_config(host):
@@ -367,9 +366,6 @@ class GetQueryHandler(IPythonHandler):
 
 class IFrameHandler(IPythonHandler):
     def initialize(self, welcome=None, sites=None):
-        print("graceal1 in initialize with")
-        print(welcome)
-        print(sites)
         self.sites = sites
         self.welcome = welcome
 

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -16,11 +16,15 @@ import requests
 import yaml
 import time
 import urllib.parse
+import constants
 
 logging.basicConfig(format='%(asctime)s %(message)s')
 
 @functools.lru_cache(maxsize=128)
 def get_maap_config(host):
+    print("graceal1 in get_maap_config and constants are")
+    print(constants.ADE_OPTIONS)
+    print(constants.API_OPTIONS)
     api_host = os.getenv("MAAP_API_HOST", "api.maap-project.org")
     maap_api_config_endpoint = os.getenv("MAAP_API_CONFIG_ENDPOINT", "api/environment/config")
     ade_host = host if host in ["ade.dit.maap-project.org", "ade.uat.maap-project.org", "ade.maap-project.org"] else os.getenv("MAAP_ADE_HOST", "ade.maap-project.org")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maap-jupyter-server-extension",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "A JupyterLab extension.",
   "keywords": [
     "jupyter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maap-jupyter-server-extension",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "description": "A JupyterLab extension.",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,7 @@ dependencies = [
     "Requests~=2.32.3",
     "setuptools~=69.0",
     "tornado~=6.4",
-    "jupyter-nbextensions-configurator~=0.6.4",
-    "maap-py@git+https://github.com/MAAP-Project/maap-py.git@feature/maappy-gets-username#egg=maapPy"
+    "jupyter-nbextensions-configurator~=0.6.4"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,11 @@ dependencies = [
     "notebook~=6.4.12",
     "pytest~=8.1.1",
     "PyYAML~=6.0.1",
-    "Requests~=2.31.0",
+    "Requests~=2.32.3",
     "setuptools~=69.0",
     "tornado~=6.4",
     "jupyter-nbextensions-configurator~=0.6.4",
-    "maap-py@git+https://github.com/MAAP-Project/maap-py.git@feature/get-username#egg=maapPy"
+    "maap-py@git+https://github.com/MAAP-Project/maap-py.git@feature/maappy-gets-username#egg=maapPy"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "setuptools~=69.0",
     "tornado~=6.4",
     "jupyter-nbextensions-configurator~=0.6.4",
-    "maap-py@git+https://github.com/MAAP-Project/maap-py.git@v4.0.0#egg=maapPy"
+    "maap-py@git+https://github.com/MAAP-Project/maap-py.git@feature/get-username#egg=maapPy"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
- can’t just use `host` parameter in the jupyter server extension `get_maap_config` function because when testing locally, host wouldn’t be the ade and this also wouldn’t be good for extractability. So the order is that, sees if host is one of the 3 ADEs, then checks to see if `MAAP_ADE_HOST` is set as an environment variable, and if neither of those are true, uses ade.maap-project.org as the default 
- No longer need the API when instantiating maap-py because it gets that from the `MAAP_API_HOST` environment variable 
- I considered error checking for jupyter server extension for `MAAP_ADE_HOST` and `MAAP_API_HOST`, but if you pass a bad `MAAP_ADE_HOST`, https://api.maap-project.org/api/environment/config/https%253A%252F%252Fksdfjhg returns ops by default which is fine. Also, for `MAAP_API_HOST` there isn’t error checking in maap-py for this env var so maybe we should remain consistent? And we don’t want to limit potential APIs the user wants to use if they are using this extension locally for another purpose (their API would have to be very similar to ours for things to work though...)
- Needed to change the version of `requests` because getting errors 
- Some expected behavior examples: If you have the DIT PGT token and `MAAP_API_HOST=api.dit.maap-project.org` and do a bad `MAAP_ADE_HOST`, you can see your DIT jobs still. If you have a DIT PGT token and `MAAP_API_HOST=api.maap-project.org`, you cannot see or submit your jobs. If you submit a job with PGT and `MAAP_API_HOST` matching environments, but you add a username field that isn’t yours, it will be overriden to submit a job with your username (soon we will edit the API so it doesn’t even require a username)

Tested:
- Seeing/ submitting jobs via the UI and via maap.submitJob in DIT, UAT, OPS, and local development from pip installs 
- Incorrectly setting the PGT token, `MAAP_API_HOST`, or `MAAP_ADE_HOST` in the ADE and with local development 
- Some expected behavior examples: If you have the DIT PGT token and `MAAP_API_HOST=api.dit.maap-project.org` and do a bad `MAAP_ADE_HOST`, you can see your DIT jobs still. If you have a DIT PGT token and `MAAP_API_HOST=api.maap-project.org`, you cannot see or submit your jobs. If you submit a job with PGT and `MAAP_API_HOST` matching environments, but you add a username field that isn’t yours, it will be overriden to submit a job with your username (soon we will edit the API so it doesn’t even require a username)

 Can test on the ADEs with this image: 'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab/python:remove-env-json'

Goes with these PRs: https://github.com/MAAP-Project/dps-jupyter-extension/pull/23 https://github.com/MAAP-Project/maap-py/pull/108