### PR TITLE
Resolve 404 error

### DIFF
--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -269,6 +269,7 @@ class GetJobResultHandler(IPythonHandler):
 
 class RegisterWithFileHandler(IPythonHandler):
     def get(self):
+        print("graceal1 in get of RegisterWithFileHandler")
         #maap = MAAP(not_self_signed=False)
         maap = MAAP()
 
@@ -280,6 +281,7 @@ class RegisterWithFileHandler(IPythonHandler):
             self.finish({"status_code": r.status_code, "response": r.text})
         except:
             print("Failed to register.")
+            self.finish()
 
 
 
@@ -319,6 +321,7 @@ class GetGranulesHandler(IPythonHandler):
         return url_list
 
     def get(self):
+        print("graceal1 in the get of getGranules")
         maap = MAAP()
         cmr_query = self.get_argument('cmr_query', '')
         limit = str(self.get_argument('limit', ''))
@@ -623,6 +626,12 @@ class CreateFileHandler(IPythonHandler):
             self.finish()
 
 
+class TestHandler(IPythonHandler):
+    def get(self):
+        print("graceal1 in test handler")
+        self.finish()
+
+
 def setup_handlers(web_app):
     host_pattern = ".*$"
 
@@ -655,10 +664,11 @@ def setup_handlers(web_app):
 
 
     # EDSC
-    web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc", "getGranules"), GetGranulesHandler)])
-    web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc", "getQuery"), GetQueryHandler)])
-    web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc"), IFrameHandler, {'welcome': welcome, 'sites': sites}), (url_path_join(base_url, 'jupyter-server-extension/edsc/proxy'), IFrameProxyHandler)])
+    #web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc", "getGranules"), GetGranulesHandler)])
+    #web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc", "getQuery"), GetQueryHandler)])
+    #web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc"), IFrameHandler, {'welcome': welcome, 'sites': sites}), (url_path_join(base_url, 'jupyter-server-extension/edsc/proxy'), IFrameProxyHandler)])
 
+    web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "test"), TestHandler)])
 
 
     web_app.add_handlers(host_pattern, handlers)

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -339,6 +339,7 @@ class GetGranulesHandler(IPythonHandler):
 
 class GetQueryHandler(IPythonHandler):
     def get(self):
+        print("graceal1 in getQueryHandler")
         maap = MAAP()
         cmr_query = self.get_argument('cmr_query', '')
         limit = str(self.get_argument('limit', ''))
@@ -664,7 +665,7 @@ def setup_handlers(web_app):
 
 
     # EDSC
-    #web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc", "getGranules"), GetGranulesHandler)])
+    web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc", "getGranules"), GetGranulesHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc", "getQuery"), GetQueryHandler)])
     #web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc"), IFrameHandler, {'welcome': welcome, 'sites': sites}), (url_path_join(base_url, 'jupyter-server-extension/edsc/proxy'), IFrameProxyHandler)])
 

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -269,7 +269,6 @@ class GetJobResultHandler(IPythonHandler):
 
 class RegisterWithFileHandler(IPythonHandler):
     def get(self):
-        print("graceal1 in get of RegisterWithFileHandler")
         #maap = MAAP(not_self_signed=False)
         maap = MAAP()
 
@@ -321,7 +320,6 @@ class GetGranulesHandler(IPythonHandler):
         return url_list
 
     def get(self):
-        print("graceal1 in the get of getGranules")
         maap = MAAP()
         cmr_query = self.get_argument('cmr_query', '')
         limit = str(self.get_argument('limit', ''))
@@ -339,7 +337,6 @@ class GetGranulesHandler(IPythonHandler):
 
 class GetQueryHandler(IPythonHandler):
     def get(self):
-        print("graceal1 in getQueryHandler")
         maap = MAAP()
         cmr_query = self.get_argument('cmr_query', '')
         limit = str(self.get_argument('limit', ''))
@@ -626,13 +623,6 @@ class CreateFileHandler(IPythonHandler):
             print("Failed to create file.")
             self.finish()
 
-
-class TestHandler(IPythonHandler):
-    def get(self):
-        print("graceal1 in test handler")
-        self.finish()
-
-
 def setup_handlers(web_app):
     host_pattern = ".*$"
 
@@ -667,10 +657,7 @@ def setup_handlers(web_app):
     # EDSC
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc", "getGranules"), GetGranulesHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc", "getQuery"), GetQueryHandler)])
-    #web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc"), IFrameHandler, {'welcome': welcome, 'sites': sites}), (url_path_join(base_url, 'jupyter-server-extension/edsc/proxy'), IFrameProxyHandler)])
-
-    web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "test"), TestHandler)])
-
+    web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc"), IFrameHandler, {'welcome': "Hello MAAP user"}), (url_path_join(base_url, 'jupyter-server-extension/edsc/proxy'), IFrameProxyHandler)])
 
     web_app.add_handlers(host_pattern, handlers)
     

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -665,7 +665,7 @@ def setup_handlers(web_app):
 
     # EDSC
     #web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc", "getGranules"), GetGranulesHandler)])
-    #web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc", "getQuery"), GetQueryHandler)])
+    web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc", "getQuery"), GetQueryHandler)])
     #web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "edsc"), IFrameHandler, {'welcome': welcome, 'sites': sites}), (url_path_join(base_url, 'jupyter-server-extension/edsc/proxy'), IFrameProxyHandler)])
 
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "test"), TestHandler)])


### PR DESCRIPTION
Fixed the 404 error for jupyter server endpoints. The problem was that `welcome` and `sites` were not defined so any endpoints added under that handler were not being found 
I could not find any cases of the /edsc endpoint being used, so I think it is okay for welcome to say "Hello MAAP user" and sites just to be null, I am not sure what these values were supposed to be. I went back through the commits and also could not find evidence of what `welcome` and `sites` were supposed to be assigned 

I also added self.finish to RegisterWithFileHandler just for consistency, this was not actually causing an error 