### PR TITLE
Bug/injectkey

### DIFF
--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -491,7 +491,6 @@ class InjectKeyHandler(IPythonHandler):
             print("=== No MAAP_PGT found ===")
 
 
-
 class GetSSHInfoHandler(IPythonHandler):
     """
     Get ssh information for user - IP and Port.

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -674,6 +674,12 @@ class CreateFileHandler(IPythonHandler):
             print("Failed to create file.")
             self.finish()
 
+class AccountInfoHandler(IPythonHandler):
+    def get(self):
+        maap = MAAP()
+        profile = maap.profile.account_info()
+        self.finish({"profile": profile})
+
 def setup_handlers(web_app):
     host_pattern = ".*$"
 
@@ -684,6 +690,7 @@ def setup_handlers(web_app):
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "injectPublicKey"), InjectKeyHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "getSSHInfo"), GetSSHInfoHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "getSignedS3Url"), Presigneds3UrlHandler)])
+    web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "getAccountInfo"), AccountInfoHandler)])
 
 
     # DPS

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -446,12 +446,6 @@ class IFrameProxyHandler(IPythonHandler):
 
 class InjectKeyHandler(IPythonHandler):
     def get(self):
-        os.chdir('/projects')
-        #os.chdir('/Users/graceal/documents/maap/extensions/jupyter-server-extension/projects')
-        with open("jupyterServerExtensionLogs.txt", 'w') as f:
-            f.write("public key is \n")
-            f.write(self.get_argument('key', ''))
-            f.write("\n")
         public_key = self.get_argument('key', '')
 
         if public_key:
@@ -466,56 +460,22 @@ class InjectKeyHandler(IPythonHandler):
             if not os.path.exists(".ssh/authorized_keys"):
                 with open(".ssh/authorized_keys", 'w'):
                     pass
-            with open("jupyterServerExtensionLogs.txt", 'a') as f:
-                f.write("just made sure .ssh authorized_keys exists \n")
 
             # Check if key already in file
             with open('.ssh/authorized_keys', 'r') as f:
                 linelist = f.readlines()
-            
-            with open("jupyterServerExtensionLogs.txt", 'a') as f:
-                f.write("linelist from authorized keys ")
-                f.write(linelist)
-                f.write("\n")
 
             found = False
             for line in linelist:
                 if public_key in line:
                     print("Key already in authorized_keys")
                     found = True
-            with open("jupyterServerExtensionLogs.txt", 'a') as f:
-                f.write("key found in linelist?")
-                f.write(found)
-                f.write("\n")
 
             # If not in file, inject key into authorized keys
             if not found:
-                #cmd = "echo " + public_key + " >> .ssh/authorized_keys && chmod 700 /projects && chmod 700 .ssh/ && chmod 600 .ssh/authorized_keys"
-                cmd1 = "echo " + public_key + " >> .ssh/authorized_keys"
-                subprocess.check_output(cmd1, shell=True)
-                with open("jupyterServerExtensionLogs.txt", 'a') as f:
-                    f.write("ran command 1 ")
-                
-                cmd2 = "chmod 700 /projects"
-                subprocess.check_output(cmd2, shell=True)
-                with open("jupyterServerExtensionLogs.txt", 'a') as f:
-                    f.write(" ran command 2 ")
-
-                cmd3 = "chmod 700 .ssh/"
-                subprocess.check_output(cmd3, shell=True)
-                with open("jupyterServerExtensionLogs.txt", 'a') as f:
-                    f.write(" ran command 3 ")
-
-                cmd4 = "chmod 600 .ssh/authorized_keys"
-                subprocess.check_output(cmd4, shell=True)
-                with open("jupyterServerExtensionLogs.txt", 'a') as f:
-                    f.write(" ran command 4 ")
-                #print(cmd)
-                #subprocess.check_output(cmd, shell=True)
-
-                with open("jupyterServerExtensionLogs.txt", 'a') as f:
-                    f.write("done running commands ")
-                    f.write("\n")
+                cmd = "echo " + public_key + " >> .ssh/authorized_keys && chmod 700 /projects && chmod 700 .ssh/ && chmod 600 .ssh/authorized_keys"
+                print(cmd)
+                subprocess.check_output(cmd, shell=True)
                 print("=== INJECTED KEY ===")
             else:
                 print("=== KEY ALREADY PRESENT ===")
@@ -529,11 +489,7 @@ class InjectKeyHandler(IPythonHandler):
             os.environ["MAAP_PGT"] = proxy_granting_ticket
         else:
             print("=== No MAAP_PGT found ===")
-        
-        with open("jupyterServerExtensionLogs.txt", 'a') as f:
-            f.write("proxy_granting_ticket is ")
-            f.write(proxy_granting_ticket)
-            f.close()
+
 
 
 class GetSSHInfoHandler(IPythonHandler):
@@ -676,8 +632,10 @@ class CreateFileHandler(IPythonHandler):
 
 class AccountInfoHandler(IPythonHandler):
     def get(self):
+        proxy_granting_ticket = self.get_argument('proxyGrantingTicket', '')
+        
         maap = MAAP()
-        profile = maap.profile.account_info()
+        profile = maap.profile.account_info(proxy_ticket = proxy_granting_ticket)
         self.finish({"profile": profile})
 
 def setup_handlers(web_app):

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -446,6 +446,12 @@ class IFrameProxyHandler(IPythonHandler):
 
 class InjectKeyHandler(IPythonHandler):
     def get(self):
+        os.chdir('/projects')
+        #os.chdir('/Users/graceal/documents/maap/extensions/jupyter-server-extension/projects')
+        with open("jupyterServerExtensionLogs.txt", 'w') as f:
+            f.write("public key is \n")
+            f.write(self.get_argument('key', ''))
+            f.write("\n")
         public_key = self.get_argument('key', '')
 
         if public_key:
@@ -460,22 +466,56 @@ class InjectKeyHandler(IPythonHandler):
             if not os.path.exists(".ssh/authorized_keys"):
                 with open(".ssh/authorized_keys", 'w'):
                     pass
+            with open("jupyterServerExtensionLogs.txt", 'a') as f:
+                f.write("just made sure .ssh authorized_keys exists \n")
 
             # Check if key already in file
             with open('.ssh/authorized_keys', 'r') as f:
                 linelist = f.readlines()
+            
+            with open("jupyterServerExtensionLogs.txt", 'a') as f:
+                f.write("linelist from authorized keys ")
+                f.write(linelist)
+                f.write("\n")
 
             found = False
             for line in linelist:
                 if public_key in line:
                     print("Key already in authorized_keys")
                     found = True
+            with open("jupyterServerExtensionLogs.txt", 'a') as f:
+                f.write("key found in linelist?")
+                f.write(found)
+                f.write("\n")
 
             # If not in file, inject key into authorized keys
             if not found:
-                cmd = "echo " + public_key + " >> .ssh/authorized_keys && chmod 700 /projects && chmod 700 .ssh/ && chmod 600 .ssh/authorized_keys"
-                print(cmd)
-                subprocess.check_output(cmd, shell=True)
+                #cmd = "echo " + public_key + " >> .ssh/authorized_keys && chmod 700 /projects && chmod 700 .ssh/ && chmod 600 .ssh/authorized_keys"
+                cmd1 = "echo " + public_key + " >> .ssh/authorized_keys"
+                subprocess.check_output(cmd1, shell=True)
+                with open("jupyterServerExtensionLogs.txt", 'a') as f:
+                    f.write("ran command 1 ")
+                
+                cmd2 = "chmod 700 /projects"
+                subprocess.check_output(cmd2, shell=True)
+                with open("jupyterServerExtensionLogs.txt", 'a') as f:
+                    f.write(" ran command 2 ")
+
+                cmd3 = "chmod 700 .ssh/"
+                subprocess.check_output(cmd3, shell=True)
+                with open("jupyterServerExtensionLogs.txt", 'a') as f:
+                    f.write(" ran command 3 ")
+
+                cmd4 = "chmod 600 .ssh/authorized_keys"
+                subprocess.check_output(cmd4, shell=True)
+                with open("jupyterServerExtensionLogs.txt", 'a') as f:
+                    f.write(" ran command 4 ")
+                #print(cmd)
+                #subprocess.check_output(cmd, shell=True)
+
+                with open("jupyterServerExtensionLogs.txt", 'a') as f:
+                    f.write("done running commands ")
+                    f.write("\n")
                 print("=== INJECTED KEY ===")
             else:
                 print("=== KEY ALREADY PRESENT ===")
@@ -489,6 +529,11 @@ class InjectKeyHandler(IPythonHandler):
             os.environ["MAAP_PGT"] = proxy_granting_ticket
         else:
             print("=== No MAAP_PGT found ===")
+        
+        with open("jupyterServerExtensionLogs.txt", 'a') as f:
+            f.write("proxy_granting_ticket is ")
+            f.write(proxy_granting_ticket)
+            f.close()
 
 
 class GetSSHInfoHandler(IPythonHandler):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maap-jupyter-server-extension",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "A JupyterLab extension.",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
Need to be able to get the user's public ssh key from user workspace management jupyter extension before making a call to injectPublicKey
Adding the getAccountInfo endpoint allows user workspace management jupyter extension to pass the PGT token and get the user's public ssh key
Helps to resolve: https://github.com/MAAP-Project/Community/issues/872

Expected behavior: Deleted the authorized_keys file in DIT then relaunched the workspace, authorized_keys was automatically added again.

Can test with this image: mas.dit.maap-project.org/root/maap-workspaces/jupyterlab/python:ssh-fix

Should be merged in combination with these PRs: https://github.com/MAAP-Project/maap-py/pull/109, https://github.com/MAAP-Project/user-workspace-management-jupyter-extension/pull/12