### PR TITLE
added injectPGT endpoint

### DIFF
--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -480,6 +480,8 @@ class InjectKeyHandler(IPythonHandler):
             else:
                 print("=== KEY ALREADY PRESENT ===")
 
+class InjectPGTHandler(IPythonHandler):
+    def get(self):
         print("=== Checking for existence of MAAP_PGT ===")
 
         proxy_granting_ticket = self.get_argument('proxyGrantingTicket', '')
@@ -645,6 +647,7 @@ def setup_handlers(web_app):
 
     # USER WORKSPACE MANAGEMENT
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "injectPublicKey"), InjectKeyHandler)])
+    web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "injectPGT"), InjectPGTHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "getSSHInfo"), GetSSHInfoHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "getSignedS3Url"), Presigneds3UrlHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "getAccountInfo"), AccountInfoHandler)])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maap-jupyter-server-extension",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "A JupyterLab extension.",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
Separated `injectPublicKey` and `injectPGT` into 2 different calls to avoid errors in `injectPublicKey` not injecting the PGT token into the environment 

Relevant PR to user workspace management extension: https://github.com/MAAP-Project/user-workspace-management-jupyter-extension/pull/14 

Can test with: `mas.dit.maap-project.org/root/maap-workspaces/jupyterlab/python:set-pgt-token`