### PR TITLE
Feature/2i2c compatibility: Release 3.0.0

### DIFF
--- a/maap_jupyter_server_extension/constants.py
+++ b/maap_jupyter_server_extension/constants.py
@@ -1,3 +1,3 @@
-ADE_OPTIONS = ["ade.dit.maap-project.org", "ade.uat.maap-project.org", "ade.maap-project.org"]
+ADE_OPTIONS = ["ade.dit.maap-project.org", "ade.uat.maap-project.org", "ade.maap-project.org", "staging.hub.maap-project.org", "hub.maap-project.org"]
 DEFAULT_ADE = "ade.maap-project.org"
 DEFAULT_API = "api.maap-project.org"

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -76,7 +76,6 @@ class WorkspaceContainerHandler(APIHandler):
     # The following decorator should be present on all verb methods (head, get, post,
     # patch, put, delete, options) to ensure only authorized user can request the
     # Jupyter server
-    @tornado.web.authenticated
     def get(self):
         dockerimage_path_default = os.getenv('DOCKERIMAGE_PATH_DEFAULT')
         dockerimage_path_base_image = os.getenv("DOCKERIMAGE_PATH_BASE_IMAGE")

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -590,16 +590,17 @@ class Presigneds3UrlHandler(IPythonHandler):
         print('expiration is {} seconds', expiration)
 
         url = '{}/api/members/self/presignedUrlS3/{}/{}?exp={}&ws={}'.format(maap_api_url(self.request.host), bucket, key, expiration, username)
-        headers = {'Accept': 'application/json', 'proxy-ticket': proxy_ticket}
-        r = requests.get(
-            url,
-            headers=headers,
-            verify=False
-        )
-        print(r.text)
+        raise Exception(url)
+        # headers = {'Accept': 'application/json', 'proxy-ticket': proxy_ticket}
+        # r = requests.get(
+        #     url,
+        #     headers=headers,
+        #     verify=False
+        # )
+        # print(r.text)
 
-        resp = json.loads(r.text)   
-        self.finish({"status_code":200, "message": "success", "url":resp['url']})
+        # resp = json.loads(r.text)   
+        # self.finish({"status_code":200, "message": "success", "url":resp['url']})
 
 
 class CreateFileHandler(IPythonHandler):

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -640,6 +640,12 @@ class AccountInfoHandler(IPythonHandler):
         profile = maap.profile.account_info(proxy_ticket = proxy_granting_ticket)
         self.finish({"profile": profile})
 
+# Is this secure??
+# class GetPGTHandler(IPythonHandler):
+#     def get(self):
+#         proxy_granting_ticket = os.environ('MAAP_PGT', '')
+#         self.finish({"MAAP_PGT": proxy_granting_ticket})
+
 def setup_handlers(web_app):
     host_pattern = ".*$"
 
@@ -652,13 +658,14 @@ def setup_handlers(web_app):
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "getSSHInfo"), GetSSHInfoHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "getSignedS3Url"), Presigneds3UrlHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "getAccountInfo"), AccountInfoHandler)])
+    #web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "getMAAPPGT"), GetPGTHandler)])
 
 
     # DPS
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "get_example"), RouteHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "getKibanaUrl"), KibanaConfigHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "getConfig"), MAAPConfigEnvironmentHandler)])
-    web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "getWorkspaceContainerr"), WorkspaceContainerHandler)])
+    web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "getWorkspaceContainer"), WorkspaceContainerHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "createFile"), CreateFileHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "listAlgorithms"), ListAlgorithmsHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "describeAlgorithms"), DescribeAlgorithmsHandler)])

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -590,7 +590,7 @@ class Presigneds3UrlHandler(IPythonHandler):
         print('expiration is {} seconds', expiration)
 
         url = '{}/api/members/self/presignedUrlS3/{}/{}?exp={}&ws={}'.format(maap_api_url(self.request.host), bucket, key, expiration, username)
-        raise Exception(url)
+        raise Exception(self.request.host)
         # headers = {'Accept': 'application/json', 'proxy-ticket': proxy_ticket}
         # r = requests.get(
         #     url,

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -452,7 +452,7 @@ class InjectKeyHandler(IPythonHandler):
             print("=== Injecting SSH KEY ===")
 
             # Check if .ssh directory exists, if not create it
-            os.chdir('/projects')
+            os.chdir('/home/jovyan')
             if not os.path.exists(".ssh"):
                 os.makedirs(".ssh")
 
@@ -473,7 +473,7 @@ class InjectKeyHandler(IPythonHandler):
 
             # If not in file, inject key into authorized keys
             if not found:
-                cmd = "echo " + public_key + " >> .ssh/authorized_keys && chmod 700 /projects && chmod 700 .ssh/ && chmod 600 .ssh/authorized_keys"
+                cmd = "echo " + public_key + " >> .ssh/authorized_keys && chmod 700 /home/jovyan && chmod 700 .ssh/ && chmod 600 .ssh/authorized_keys"
                 print(cmd)
                 subprocess.check_output(cmd, shell=True)
                 print("=== INJECTED KEY ===")

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -658,7 +658,7 @@ def setup_handlers(web_app):
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "get_example"), RouteHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "getKibanaUrl"), KibanaConfigHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "getConfig"), MAAPConfigEnvironmentHandler)])
-    web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "getWorkspaceContainer"), WorkspaceContainerHandler)])
+    web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "getWorkspaceContainerr"), WorkspaceContainerHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "createFile"), CreateFileHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "listAlgorithms"), ListAlgorithmsHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "describeAlgorithms"), DescribeAlgorithmsHandler)])

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -590,17 +590,16 @@ class Presigneds3UrlHandler(IPythonHandler):
         print('expiration is {} seconds', expiration)
 
         url = '{}/api/members/self/presignedUrlS3/{}/{}?exp={}&ws={}'.format(maap_api_url(self.request.host), bucket, key, expiration, username)
-        raise Exception(self.request.host)
-        # headers = {'Accept': 'application/json', 'proxy-ticket': proxy_ticket}
-        # r = requests.get(
-        #     url,
-        #     headers=headers,
-        #     verify=False
-        # )
-        # print(r.text)
+        headers = {'Accept': 'application/json', 'proxy-ticket': proxy_ticket}
+        r = requests.get(
+            url,
+            headers=headers,
+            verify=False
+        )
+        print(r.text)
 
-        # resp = json.loads(r.text)   
-        # self.finish({"status_code":200, "message": "success", "url":resp['url']})
+        resp = json.loads(r.text)   
+        self.finish({"status_code":200, "message": "success", "url":resp['url']})
 
 
 class CreateFileHandler(IPythonHandler):

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -78,7 +78,6 @@ class WorkspaceContainerHandler(APIHandler):
     # Jupyter server
     #@tornado.web.authenticated
     def get(self):
-        print("graceal1 in WorkspaceContainerHandler")
         dockerimage_path_default = os.getenv('DOCKERIMAGE_PATH_DEFAULT')
         dockerimage_path_base_image = os.getenv("DOCKERIMAGE_PATH_BASE_IMAGE")
         self.finish({"DOCKERIMAGE_PATH_DEFAULT": dockerimage_path_default, "DOCKERIMAGE_PATH_BASE_IMAGE": dockerimage_path_base_image})
@@ -453,7 +452,8 @@ class InjectKeyHandler(IPythonHandler):
             print("=== Injecting SSH KEY ===")
 
             # Check if .ssh directory exists, if not create it
-            os.chdir('/home/jovyan')
+            home_dir = os.environ.get("JUPYTER_SERVER_ROOT", "/home/jovyan")
+            os.chdir(home_dir)
             if not os.path.exists(".ssh"):
                 os.makedirs(".ssh")
 
@@ -474,7 +474,7 @@ class InjectKeyHandler(IPythonHandler):
 
             # If not in file, inject key into authorized keys
             if not found:
-                cmd = "echo " + public_key + " >> .ssh/authorized_keys && chmod 700 /home/jovyan && chmod 700 .ssh/ && chmod 600 .ssh/authorized_keys"
+                cmd = "echo " + public_key + " >> .ssh/authorized_keys && chmod 700 " + home_dir + " && chmod 700 .ssh/ && chmod 600 .ssh/authorized_keys"
                 print(cmd)
                 subprocess.check_output(cmd, shell=True)
                 print("=== INJECTED KEY ===")
@@ -640,11 +640,14 @@ class AccountInfoHandler(IPythonHandler):
         profile = maap.profile.account_info(proxy_ticket = proxy_granting_ticket)
         self.finish({"profile": profile})
 
-# Is this secure??
-# class GetPGTHandler(IPythonHandler):
-#     def get(self):
-#         proxy_granting_ticket = os.environ('MAAP_PGT', '')
-#         self.finish({"MAAP_PGT": proxy_granting_ticket})
+class AccountInfoPGTENVHandler(IPythonHandler):
+    @tornado.web.authenticated
+    def get(self):
+        proxy_granting_ticket = os.environ.get('MAAP_PGT', '')
+
+        maap = MAAP()
+        profile = maap.profile.account_info(proxy_ticket = proxy_granting_ticket)
+        self.finish({"profile": profile})
 
 def setup_handlers(web_app):
     host_pattern = ".*$"
@@ -658,7 +661,7 @@ def setup_handlers(web_app):
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "getSSHInfo"), GetSSHInfoHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "getSignedS3Url"), Presigneds3UrlHandler)])
     web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "getAccountInfo"), AccountInfoHandler)])
-    #web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "getMAAPPGT"), GetPGTHandler)])
+    web_app.add_handlers(host_pattern, [(url_path_join(base_url, "jupyter-server-extension", "uwm", "getAccountInfoFromPGTENV"), AccountInfoPGTENVHandler)])
 
 
     # DPS

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -76,7 +76,9 @@ class WorkspaceContainerHandler(APIHandler):
     # The following decorator should be present on all verb methods (head, get, post,
     # patch, put, delete, options) to ensure only authorized user can request the
     # Jupyter server
+    #@tornado.web.authenticated
     def get(self):
+        print("graceal1 in WorkspaceContainerHandler")
         dockerimage_path_default = os.getenv('DOCKERIMAGE_PATH_DEFAULT')
         dockerimage_path_base_image = os.getenv("DOCKERIMAGE_PATH_BASE_IMAGE")
         self.finish({"DOCKERIMAGE_PATH_DEFAULT": dockerimage_path_default, "DOCKERIMAGE_PATH_BASE_IMAGE": dockerimage_path_base_image})

--- a/maap_jupyter_server_extension/handlers.py
+++ b/maap_jupyter_server_extension/handlers.py
@@ -549,7 +549,8 @@ class Presigneds3UrlHandler(IPythonHandler):
         abs_path = os.path.join(rt_path, key)
         proxy_ticket = self.get_argument('proxy-ticket','')
         expiration = self.get_argument('duration','86400') # default 24 hrs
-        che_ws_namespace = os.environ.get('CHE_WORKSPACE_NAMESPACE')
+        # This is replacing the workspace name because the buckets correspond to the username
+        username = self.get_argument('username', '')
 
         print('bucket is '+bucket)     
         print('key is '+key)        
@@ -588,7 +589,7 @@ class Presigneds3UrlHandler(IPythonHandler):
         # expiration = '43200' # 12 hrs in seconds
         print('expiration is {} seconds', expiration)
 
-        url = '{}/api/members/self/presignedUrlS3/{}/{}?exp={}&ws={}'.format(maap_api_url(self.request.host), bucket, key, expiration, che_ws_namespace)
+        url = '{}/api/members/self/presignedUrlS3/{}/{}?exp={}&ws={}'.format(maap_api_url(self.request.host), bucket, key, expiration, username)
         headers = {'Accept': 'application/json', 'proxy-ticket': proxy_ticket}
         r = requests.get(
             url,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maap-jupyter-server-extension",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "A JupyterLab extension.",
   "keywords": [
     "jupyter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maap-jupyter-server-extension",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "A JupyterLab extension.",
   "keywords": [
     "jupyter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maap-jupyter-server-extension",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "description": "A JupyterLab extension.",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
- Added new default ADE options to support 2i2c 
- removed @tornado.web.authenticated for getting the container urls because this was causing errors and this is not sensitive information 
- user root is now /home/jovyan and not /projects -> this is why I changed the major version for this release 
- using the username for the workspace instead of che workspace id which is no longer an env var 
- added the getAccountInfoFromPGTENV endpoint because the way we do authentication changed so we need to get the PGT from env vars to get the profile instead of passing that into jupyter server extension because we can't get the token from keycloak anymore 